### PR TITLE
feat!: stricter custom headers, pass through sdkVersion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ interface IConfig extends IStaticContext {
     impressionDataAll?: boolean;
     usePOSTrequests?: boolean;
     experimental?: IExperimentalConfig;
+    sdkVersion?: string;
 }
 
 interface IExperimentalConfig {
@@ -172,6 +173,7 @@ export class UnleashClient extends TinyEmitter {
     private experimental: IExperimentalConfig;
     private lastRefreshTimestamp: number;
     private connectionId: string;
+    private sdkVersion: string | undefined;
 
     constructor({
         storageProvider,
@@ -194,6 +196,7 @@ export class UnleashClient extends TinyEmitter {
         impressionDataAll = false,
         usePOSTrequests = false,
         experimental,
+        sdkVersion,
     }: IConfig) {
         super();
         // Validations
@@ -272,6 +275,7 @@ export class UnleashClient extends TinyEmitter {
         this.bootstrapOverride = bootstrapOverride;
 
         this.connectionId = uuidv4();
+        this.sdkVersion = sdkVersion;
 
         this.metrics = new Metrics({
             onError: this.emit.bind(this, EVENTS.ERROR),
@@ -286,6 +290,7 @@ export class UnleashClient extends TinyEmitter {
             customHeaders,
             metricsIntervalInitial,
             connectionId: this.connectionId,
+            sdkVersion,
         });
     }
 
@@ -487,6 +492,7 @@ export class UnleashClient extends TinyEmitter {
             headerName: this.headerName,
             etag: this.etag,
             isPost: this.usePOSTrequests,
+            sdkVersion: this.sdkVersion,
         });
     }
 
@@ -636,6 +642,11 @@ export class UnleashClient extends TinyEmitter {
                 this.abortController = null;
             }
         }
+    }
+
+    public setSdkVersion(sdkVersion: string): void {
+        this.sdkVersion = sdkVersion;
+        this.metrics.setSdkVersion(sdkVersion);
     }
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -15,6 +15,7 @@ export interface MetricsOptions {
     customHeaders?: Record<string, string>;
     metricsIntervalInitial: number;
     connectionId: string;
+    sdkVersion?: string;
 }
 
 interface VariantBucket {
@@ -55,6 +56,7 @@ export default class Metrics {
     private customHeaders: Record<string, string>;
     private metricsIntervalInitial: number;
     private connectionId: string;
+    private sdkVersion: string | undefined;
 
     constructor({
         onError,
@@ -69,6 +71,7 @@ export default class Metrics {
         customHeaders = {},
         metricsIntervalInitial,
         connectionId,
+        sdkVersion,
     }: MetricsOptions) {
         this.onError = onError;
         this.onSent = onSent || doNothing;
@@ -83,6 +86,7 @@ export default class Metrics {
         this.headerName = headerName;
         this.customHeaders = customHeaders;
         this.connectionId = connectionId;
+        this.sdkVersion = sdkVersion;
     }
 
     public start() {
@@ -128,6 +132,7 @@ export default class Metrics {
             customHeaders: this.customHeaders,
             headerName: this.headerName,
             isPost: true,
+            sdkVersion: this.sdkVersion,
         });
     }
 
@@ -209,5 +214,9 @@ export default class Metrics {
             appName: this.appName,
             instanceId: 'browser',
         };
+    }
+
+    public setSdkVersion(sdkVersion: string): void {
+        this.sdkVersion = sdkVersion;
     }
 }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -158,7 +158,10 @@ describe('parseHeaders', () => {
         const customHeaders = {
             'custom-header': 'custom-value',
             'unleash-connection-id': 'should-not-be-overwritten',
-            'unleash-appname': 'new-app-name',
+            'unleash-appname': 'should-not-be-overwritten-either',
+            'another-custom-header': 'another-custom-value',
+            'content-type': 'this-will-be-dropped',
+            'if-none-match': 'this-will-be-dropped-too',
         };
         const result = parseHeaders({
             clientKey,
@@ -167,11 +170,12 @@ describe('parseHeaders', () => {
             customHeaders,
         });
 
-        expect(Object.keys(result)).toHaveLength(6);
+        expect(Object.keys(result)).toHaveLength(7);
         expect(result).toMatchObject({
             'custom-header': 'custom-value',
             'unleash-connection-id': connectionId,
-            'unleash-appname': 'new-app-name',
+            'unleash-appname': appName,
+            'another-custom-header': 'another-custom-value',
         });
     });
 
@@ -234,5 +238,16 @@ describe('parseHeaders', () => {
         });
 
         expect(result['content-type']).toBe('application/json');
+    });
+
+    test('should support specifying an SDK version', () => {
+        const result = parseHeaders({
+            clientKey,
+            appName,
+            connectionId,
+            sdkVersion: 'my-awesome-sdk:1.33.7',
+        });
+
+        expect(result['unleash-sdk']).toBe('my-awesome-sdk:1.33.7');
     });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const sdkVersion = `unleash-js-sdk:__VERSION__`;
+export const jsSDKVersion = `unleash-js-sdk:__VERSION__`;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3762/proper-frontend-sdk-name-reporting

Implements stricter custom headers and allows consumer SDKs to pass through their SDK version.

The new custom header rules are more consistent with the rules in other SDKs (e.g. [unleash-ios-sdk](https://github.com/Unleash/unleash-ios-sdk?tab=readme-ov-file#custom-http-headers)). Due to these stricter custom header rules, your current custom headers may stop working as expected. As such, this requires a new major version.

There are two ways of passing through SDK version:
- Unleash client's `config`
- New Unleash client `setSdkVersion` method