### PR TITLE
feat: improve error handling in metrics and fetch toggles

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -653,15 +653,22 @@ test('Should publish error when initial init fails', (done) => {
         storageProvider,
     };
     const client = new UnleashClient(config);
-    client.start();
+
+    let errorReceived = false;
     client.on(EVENTS.ERROR, (e: any) => {
-        expect(e).toBe(givenError);
-        done();
+        if (!errorReceived) {
+            errorReceived = true;
+            expect(e).toBe(givenError);
+            done();
+        }
     });
+    client.start();
 });
 
 test('Should publish error when fetch fails', (done) => {
-    const givenError = new Error('Error');
+    const givenError = new Error(
+        JSON.stringify({ error: 'Error', type: 'fetch-toggles' })
+    );
 
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     fetchMock.mockReject(givenError);
@@ -674,7 +681,10 @@ test('Should publish error when fetch fails', (done) => {
     const client = new UnleashClient(config);
     client.start();
     client.on(EVENTS.ERROR, (e: any) => {
-        expect(e).toBe(givenError);
+        expect(e).toStrictEqual({
+            type: 'fetch-toggles',
+            error: givenError,
+        });
         done();
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,8 @@ export class UnleashClient extends TinyEmitter {
         this.connectionId = uuidv4();
 
         this.metrics = new Metrics({
-            onError: this.emit.bind(this, EVENTS.ERROR),
+            onError: (err) =>
+                this.emit(EVENTS.ERROR, { type: 'metrics', error: err }),
             onSent: this.emit.bind(this, EVENTS.SENT),
             appName,
             metricsInterval,
@@ -629,7 +630,10 @@ export class UnleashClient extends TinyEmitter {
                         e
                     );
                     this.sdkState = 'error';
-                    this.emit(EVENTS.ERROR, e);
+                    this.emit(EVENTS.ERROR, {
+                        type: 'fetch-toggles',
+                        error: e,
+                    });
                     this.lastError = e;
                 }
             } finally {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #263 | https://github.com/Unleash/unleash/issues/10620

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

src/index.ts


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

This pull request improves error event handling in the `UnleashClient` class to provide more context about where errors originate. Now, when an error is emitted, it includes a `type` field indicating the source of the error, making it easier to debug and handle errors appropriately.

**Enhanced error event payloads:**

* Updated the `onError` handler in the `Metrics` instantiation to emit errors with a payload containing the error type (`'metrics'`) and the error object, instead of just the error.
* Modified error emission during toggle fetching to include the error type (`'fetch-toggles'`) and the error object, instead of just the error.
